### PR TITLE
grab continuation plugin's version via the build project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,16 @@
-versionWithGit
+import metabuild.BuildInfo._
+
+// versionWithGit
+
+version := scalaDistVersion
 
 scalaVersion := version.value
 
 libraryDependencies += "org.scala-lang" % "scala-dist" % version.value
 
-// TODO: find out how to enable continuations plugin. also un-comment ContinuationsTest afterwards!
-// http://stackoverflow.com/questions/24755254/how-to-enable-compiler-plugin-from-librarydependencies
+autoCompilerPlugins := true
 
-//autoCompilerPlugins := true
+libraryDependencies +=
+  compilerPlugin("org.scala-lang.plugins" % ("scala-continuations-plugin_" + version.value) % continuationPluginVersion)
 
-//val addContinuationsPlugin = taskKey[Unit]("Add continuations plugin")
-
-//addContinuationsPlugin := {
-//  println(update.value.allModules.find(_.name contains "continuations-plugin"))
-//  compilerPlugin(update.value.allModules.find(_.name contains "continuations-plugin").get)
-//}
-
-//libraryDependencies += compilerPlugin(update.value.allModules.find(_.name contains "continuations-plugin").get)
-
-//scalacOptions += "-P:continuations:enable"
+scalacOptions += "-P:continuations:enable"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,25 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+import metabuild.Dependencies._
+import metabuild.Configs._
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+lazy val continuationPluginVersion = taskKey[String]("version of the continuation plugin")
+
+lazy val build = (project in file(".")).
+  configs(BogusConfig).
+  settings(inConfig(BogusConfig)(Defaults.configSettings): _*).
+  settings(buildInfoSettings: _*).
+  settings(addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4"): _*).
+  settings(
+    resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven",
+    libraryDependencies += "org.scala-lang" % "scala-dist" % scalaDistVersion % BogusConfig,
+    sourceGenerators in Compile <+= buildInfo,
+    buildInfoKeys := Seq[BuildInfoKey](
+      "scalaDistVersion" -> scalaDistVersion,
+      continuationPluginVersion
+    ),
+    buildInfoPackage := "metabuild",
+    continuationPluginVersion := {
+    	val bogusClasspath = (externalDependencyClasspath in BogusConfig).value
+    	val f = (bogusClasspath find { _.data.getName contains "continuations-plugin" }).get.data
+    	f.getName.replaceAllLiterally("scala-continuations-plugin_" + scalaDistVersion + "-", "").replaceAllLiterally(".jar", "")
+    }
+  )

--- a/project/project/Dependencies.scala
+++ b/project/project/Dependencies.scala
@@ -1,0 +1,11 @@
+package metabuild
+
+import sbt._
+
+object Dependencies {
+  def scalaDistVersion = sys.props("project.version")
+}
+
+object Configs {
+  lazy val BogusConfig = config("bogus")
+}

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")


### PR DESCRIPTION
I'll post an answer http://stackoverflow.com/questions/24755254/how-to-enable-compiler-plugin-from-librarydependencies
