### PR TITLE
Enable the continuations plugin.

### DIFF
--- a/src/main/scala/scaladist/ContinuationsTest.scala
+++ b/src/main/scala/scaladist/ContinuationsTest.scala
@@ -3,14 +3,13 @@ package scaladist
 import scala.util.continuations._
 
 object ContinuationsTest {
-  /*
   def foo(): Int @cps[Int] = { // could leave out return type
     shift { k: (Int=>Int) =>
       k(7)
     } + 1
   }
-  */
+
   def test(): Unit = {
-    // assert(reset(2 * foo()) == 16)
+    assert(reset(2 * foo()) == 16)
   }
 }


### PR DESCRIPTION
With the minimal amount of contortions.

We bypass the `autoCompilerPlugins` feature of SBT in favour
of directly building up `scalacOptions` based on the resolved
classpath, which contains the version of the continutions plugin
specified in scala-dist's POM.

I've introduced a key for the scala-dist version, rather
than using `version` directly. This was mostly so I could
test this locally, and probably isn't the right way. But
the README needs to be fleshed out to guide me down the
right path.
