### PR TITLE
Be explicit about SBT version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11


### PR DESCRIPTION
Using the latest stable release, 0.13.11.

I'm hoping that an SBT upgrade might fix an intermittent hang we
see in CI:

Example:

   https://scala-ci.typesafe.com/job/scala-2.11.x-release-smoketest/402/console

```
[info] Loading project definition from /home/jenkins/workspace/scala-2.11.x-release-smoketest/project
[info] Updating {file:/home/jenkins/workspace/scala-2.11.x-release-smoketest/project/}scala-2-11-x-release-smoketest-build...
[info] Resolving org.scala-sbt#global-plugins;0.0 ...
[info] Resolving com.typesafe.sbt#sbt-git;0.6.4 ...
[info] Resolving com.typesafe.sbt#sbt-git;0.6.4 ...
[info] Resolving org.eclipse.jgit#org.eclipse.jgit.pgm;3.3.2.201404171909-r ...
[info] Resolving org.eclipse.jgit#org.eclipse.jgit.pgm;3.3.2.201404171909-r ...
[info] Resolving org.eclipse.jgit#org.eclipse.jgit-parent;3.3.2.201404171909-r ...
[info] Resolving org.eclipse.jgit#org.eclipse.jgit-parent;3.3.2.201404171909-r ...
...hours pass
```

Review by @lrytz 
