### PR TITLE
scala-xml is no longer bundled

### DIFF
--- a/src/main/scala/scaladist/Main.scala
+++ b/src/main/scala/scaladist/Main.scala
@@ -4,7 +4,6 @@ import scala.util.Properties.versionString
 
 object Main extends App {
   println(s"scala.util.Properties.versionString: $versionString")
-  XmlTest.test()
   ScalapTest.test()
   ReflectTest.test()
 }

--- a/src/main/scala/scaladist/XmlTest.scala
+++ b/src/main/scala/scaladist/XmlTest.scala
@@ -1,9 +1,0 @@
-package scaladist
-
-object XmlTest {
-  def test(): Unit = {
-    <hallo>mai mai</hallo> match {
-      case <hallo>{text}</hallo> => assert(text.toString == "mai mai")
-    }
-  }
-}


### PR DESCRIPTION
I considered keeping the test around by adding scala-xml
to libraryDependencies.  but on the balance, I think it's
better to just get rid of it.  my reasoning:

* what version would we test with? there's no longer a single
  blessed version
* scala-xml's own tests and maintainers are a backstop on this
* the Scala community build is a backstop on this

/cc @ashawley

context is https://github.com/scala/scala/pull/6436