### PR TITLE
sbt version bump (0.13.13 -> 0.13.17)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17


### PR DESCRIPTION
I'm hoping this might fix recent Travis-CI failures on the 2.13.x
branch, but it's good to have regardless