### PR TITLE
fix version number format to be Scala Steward friendly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-versionWithGit
-
+version := sys.props.get("project.version").getOrElse("2.13.10")
 scalaVersion := version.value
-
 libraryDependencies += "org.scala-lang" % "scala-dist" % version.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")

--- a/scripts/jobs/release/smoketest
+++ b/scripts/jobs/release/smoketest
@@ -20,7 +20,7 @@ if [[ "$TRAVIS_EVENT_TYPE" == "api" ]]; then
   ensureVersion
 else
   # Use some recent version to validate changes in smoketest itself
-  version="2.13.6"
+  version="2.13.10"
 fi
 
 clearIvyCache


### PR DESCRIPTION
it appears to me that we weren't really using anything about sbt-git except the behavior it has of setting `version` (the sbt setting) based on `project.version` (the system property). but we can do that ourselves easily enough

note that we stopped making tags at https://github.com/scala/scala-dist-smoketest/tags ages ago and apparently it doesn't matter

fixes #45
